### PR TITLE
Issue in building civkit-node due to a submodule

### DIFF
--- a/lightning-invoice/src/lib.rs
+++ b/lightning-invoice/src/lib.rs
@@ -30,8 +30,6 @@ compile_error!("at least one of the `std` or `no-std` features must be enabled")
 pub mod payment;
 pub mod utils;
 
-pub(crate) mod time_utils;
-
 extern crate bech32;
 extern crate bitcoin_hashes;
 #[macro_use] extern crate lightning;

--- a/lightning-invoice/src/time_utils.rs
+++ b/lightning-invoice/src/time_utils.rs
@@ -1,1 +1,0 @@
-../../lightning/src/util/time.rs


### PR DESCRIPTION
I am having issue with running `cargo build` for civkit-node on my windows machine, On debugging, I found this submodule icon inside `/lightning-invoice/src`:-

![Screenshot (320)](https://github.com/civkit/rust-lightning-wizards/assets/44242169/5933801c-ee14-46b1-aaa5-807515f2eed7)

It appears that the contents of the file `lightning-invoice/src/time_utils.rs` have been relocated to `/lightning/src/util/time.rs` and the file no longer needed, I have tried fixing that in this PR. 