### PR TITLE
Add boilerplate for risk engine

### DIFF
--- a/lightning-risk-engine/Cargo.toml
+++ b/lightning-risk-engine/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "lightning-risk-engine"
+authors = ["Antoine Riard"]
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/civkit/rust-lightning-wizards.git"
+description = """
+Risk management engine to allow Rust Lightning users to hedge lightning security risks.
+"""
+version = "0.0.1"
+edition = "2018"

--- a/lightning-risk-engine/src/lib.rs
+++ b/lightning-risk-engine/src/lib.rs
@@ -1,0 +1,8 @@
+// This file is Copyright its original authors, visible in version control
+// history.
+//
+// This file is licensed under the Apache License, Version 2.0 <LICENSE-APACHE
+// or http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your option.
+// You may not use this file except in accordance with one or both of these
+// licenses.

--- a/lightning-risk-engine/src/risk_engine.rs
+++ b/lightning-risk-engine/src/risk_engine.rs
@@ -1,0 +1,28 @@
+// This file is Copyright its original authors, visible in version control
+// history.
+//
+// This file is licensed under the Apache License, Version 2.0 <LICENSE-APACHE
+// or http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your option.
+// You may not use this file except in accordance with one or both of these
+// licenses.
+
+use crate::events::Event;
+
+use bitcoin::secp256k1::PublicKey;
+
+struct CounterpartyAccount {
+	their_node_id: PublicKey,
+}
+
+pub struct RiskEngine {
+	list_accounts: Vec<CounterpartyAccount>
+
+	//TODO: add credentials config
+}
+
+impl RiskEngine {
+	fn handle_open_channel_request(their_node_id: PublicKey, channel_request: events::OpenChannelRequest) -> bool {
+		return true;
+	}
+}


### PR DESCRIPTION
In light of the current safety issues of lightning channels relying on pre-signed transactions and good p2p propagation, one wishing to achieve some level of funds safety of its lightning node might rely on premium fees pre-paid equivalent to a percentage of channel balances. Those premium fees can be implemented by the usage of on-chain paid credentials (e.g https://github.com/civkit/staking-credentials).

In the worst-case of transactions not confirming, the premium fees cover the channel balance amount lost and as such some economic equilibrium is achieved for the lightning node. This paradigm might come with a costliness downgrade of channel operations for the counterparty, and is only a best-effort at the lightning-level until better mitigations are deployed on the base-layer. In an optimistic future, such API will be at the very least useful to mitigate liquidity griefing affecting multi-party transactions (splicing, dual-funding, etc).

Downstream of orage node.